### PR TITLE
fix: point modal provider at OCI pool proxy instead of direct Modal API

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -282,13 +282,13 @@
     "modal": {
       "npm": "@ai-sdk/openai-compatible",
       "options": {
-        "baseURL": "https://api.us-west-2.modal.direct/v1",
-        "apiKey": "modalresearch_kCkiHCa0GiY8byjM59lG6myK0KS9ACaKVsnHPSErm5Y"
+        "baseURL": "http://92.5.60.87:4100/modal/v1",
+        "apiKey": "sk-sin-fleet-master"
       },
       "models": {
         "glm-5.1-fp8": {
           "id": "zai-org/GLM-5.1-FP8",
-          "name": "GLM 5.1 FP8 (Modal Direct)",
+          "name": "GLM 5.1 FP8 (Modal Pool Proxy)",
           "limit": {
             "context": 204800,
             "output": 131072


### PR DESCRIPTION
## Summary
- Fixes #9: `opencode.json` modal provider was pointing at the direct Modal API (`https://api.us-west-2.modal.direct/v1`) with a research key, bypassing the OCI pool proxy entirely
- Changed `baseURL` to OCI pool proxy (`http://92.5.60.87:4100/modal/v1`) and `apiKey` to gateway key (`sk-sin-fleet-master`)
- Updated model name to reflect pool proxy path

## Root Cause
The direct Modal research API key was being sent to the OCI gateway as a Bearer token → gateway rejected it with `{"error": "invalid gateway key"}`. This made it look like "no keys available" when the real issue was authentication mismatch.

## Verification
```bash
# OCI proxy models endpoint — ALIVE:
curl http://92.5.60.87:4100/modal/v1/models
# → {"data":[{"id":"zai-org/GLM-5.1-FP8",...}]}

# E2E completion via pool proxy — WORKING:
curl -X POST http://92.5.60.87:4100/modal/v1/chat/completions \
  -H "Authorization: Bearer sk-sin-fleet-master" \
  -d '{"model":"zai-org/GLM-5.1-FP8","messages":[{"role":"user","content":"hello"}],"max_tokens":20}'
# → 200 OK with GLM response

# Pool status — 3 keys available:
curl http://92.5.60.87:8090/pool/status
# → {"total_keys":3,"available":3,"checked_out":0}
```

## Architecture
```
BEFORE (BROKEN):
  opencode.json → direct Modal URL + research key
  OCI proxy rejects research key → "invalid gateway key"

AFTER (FIXED):
  opencode.json → OCI proxy URL + gateway key
  gateway → modal_proxy → pool_service → Modal API ✅
```

Closes #9